### PR TITLE
Add styling flexibility, "no events" message

### DIFF
--- a/mod_civievent.xml
+++ b/mod_civievent.xml
@@ -22,7 +22,12 @@
   <config>
     <fields name="params" addfieldpath="/modules/mod_civievent/elements">
       <fieldset name="basic">
-        
+        <field name="includecss" type="radio" default="0" label="Include CSS?" description="Indicates if the default module stylesheet should be injected into the rendering.">
+          <option value="0">No</option>
+          <option value="1">Yes</option>
+        </field>
+        <field name="noeventtext" type="text" default="No events were found" label="No Events Text" description="Text to be shown if no events are found.  Leave blank for none."></field>
+
         <field type="spacer" label="&lt;b&gt;Choose how events will be selected&lt;/b&gt;" />
         
         <field name="mode" type="list" default="0" label="Selection Mode" description="Choose event selection method">

--- a/tmpl/default.php
+++ b/tmpl/default.php
@@ -15,83 +15,94 @@ if ( $displayParams['modal'] ) {
   jimport( 'joomla.html.html.behavior' );
   JHtmlBehavior::modal();
 }
-?>
 
-<link rel="stylesheet" href="modules/mod_civievent/civievent.css" type="text/css" />
-
-<?php 
-echo '<ul class="civieventlist">';
-
-// Set number of records to be displayed and clear counter
-$maxevents = ( $displayParams['maxevents'] ) ? $displayParams['maxevents'] : 10;
-
-$x = 1;
-
-foreach ($eventtitles as &$event) {	
-
-	if ($x > $maxevents) {
-		return;
-	}
-  else {
-		$x++;
-	}   
-    
-  $baselink = 'index.php?option=com_civicrm&task=civicrm/event/';
-    
-	for ($i=0, $n=count( $event->title ); ($i < $n) ; $i++) {
-    if($displayParams['link']==1) { //link set to register
-      $link = JRoute::_( $baselink.'register&reset=1&id='.$event->eventID );
-      $modallink = JRoute::_( $baselink.'register&reset=1&id='.$event->eventID.'&tmpl=component' );
-    }
-    else { //link set to info page
-      $link = JRoute::_( $baselink.'info&reset=1&id='.$event->eventID );
-      $modallink = JRoute::_( $baselink.'info&reset=1&id='.$event->eventID.'&tmpl=component' );
-      $registernow = JRoute::_( $baselink.'register&reset=1&id='.$event->eventID );
-		}
-		
-    if ($displayParams['itemid']) {
-      $link .= '&Itemid='.$displayParams['itemid'];
-      $modallink .= '&Itemid='.$displayParams['itemid'];
-
-      if($registernow) {
-        $registernow .= '&Itemid='.$displayParams['itemid'];
-      }
-    }
-
-		// Format date
-		$event->start_date = JHtml::date( $event->start_date, $displayParams['dateformat'] );
-		if ($event->end_date) {
-			$event->end_date = JHtml::date( $event->end_date, $displayParams['dateformat'] );
-		}
-		
-		if ($event->end_date) {
-			$eventdate = $event->start_date." &#8211;".$event->end_date;
-		}
-    else {
-			$eventdate = $event->start_date;
-		}
-		
-		// Build html
-		if( $displayParams['modal'] ) {
-			$linkhtml = '<li><a class="modal" href="'.$modallink.'" rel="{handler: \'iframe\', size: {x: 520, y: 400}}">'.$event->title.'</a>';
-		}
-    else {
-			$linkhtml = '<li><a href="'.$link.'" class="class_name">'.$event->title.'</a>';
-		}
-		echo $linkhtml;
-		
-		if ( $displayParams['link']==2 ) {
-			echo '<br /><span class="eventregisternow">&raquo; <a href="'.$registernow.'">Register Now</a></span>';
-		}
-		if ( $displayParams['showdates'] ) {
-			echo '<br /><span class="eventdate">'.$eventdate.'</span>';
-		}
-		//Display summary text IF configured, and IF exists
-    if ( $displayParams['summary']==1 AND $event->summary ) {
-			echo '<br /><span class="eventsummary">'.$event->summary.'</span>';
-		}
-		echo '</li>';
-  }
+if ($params->get('includecss',0)) {
+  $cssdoc = JFactory::getDocument()->addStyleSheet("modules/mod_civievent/civievent.css");
 }
 
-echo '</ul>';
+if (count($eventtitles)) {
+  echo '<ul class="civieventlist">';
+  
+  // Set number of records to be displayed and clear counter
+  $maxevents = ( $displayParams['maxevents'] ) ? $displayParams['maxevents'] : 10;
+  
+  $x = 1;
+  
+  foreach ($eventtitles as &$event) {	
+  
+  	if ($x > $maxevents) {
+  		return;
+  	}
+    else {
+  		$x++;
+  	}   
+      
+    $baselink = 'index.php?option=com_civicrm&task=civicrm/event/';
+      
+  	for ($i=0, $n=count( $event->title ); ($i < $n) ; $i++) {
+      if($displayParams['link']==1) { //link set to register
+        $link = JRoute::_( $baselink.'register&reset=1&id='.$event->eventID );
+        $modallink = JRoute::_( $baselink.'register&reset=1&id='.$event->eventID.'&tmpl=component' );
+      }
+      else { //link set to info page
+        $link = JRoute::_( $baselink.'info&reset=1&id='.$event->eventID );
+        $modallink = JRoute::_( $baselink.'info&reset=1&id='.$event->eventID.'&tmpl=component' );
+        $registernow = JRoute::_( $baselink.'register&reset=1&id='.$event->eventID );
+  		}
+  		
+      if ($displayParams['itemid']) {
+        $link .= '&Itemid='.$displayParams['itemid'];
+        $modallink .= '&Itemid='.$displayParams['itemid'];
+  
+        if($registernow) {
+          $registernow .= '&Itemid='.$displayParams['itemid'];
+        }
+      }
+  
+  		// Format date
+  		$event->start_date = JHtml::date( $event->start_date, $displayParams['dateformat'] );
+  		if ($event->end_date) {
+  			$event->end_date = JHtml::date( $event->end_date, $displayParams['dateformat'] );
+  		}
+  		
+  		if ($event->end_date) {
+  			$eventdate = $event->start_date." &#8211;".$event->end_date;
+  		}
+      else {
+  			$eventdate = $event->start_date;
+  		}
+  		
+  		// Build html
+  		$thehtml = "<li class=\"civieventlist-item\">";
+  		if( $displayParams['modal'] ) {
+  			$linkhtml = '<a class="modal civieventlist-item-title-link" href="'.$modallink.
+  			            '" rel="{handler: \'iframe\', size: {x: 520, y: 400}}">'.$event->title.'</a>';
+  		}
+      else {
+  			$linkhtml = '<a href="'.$link.'" class="civieventlist-item-title-link">'.$event->title.'</a>';
+  		}
+  		$thehtml .= "<div class=\"civieventlist-item-title\">$linkhtml</div>";
+  		
+  		if ( $displayParams['link']==2 ) {
+  		  $thehtml .= "<div class=\"civieventlist-item-register\">" .
+  		              "<span class=\"eventregisternow\">&raquo; <a href=\"$registernow\">Register Now</a></span>" .
+  		              "</div>";
+  		}
+  		if ( $displayParams['showdates'] ) {
+  		  $thehtml .= "<div class=\"civieventlist-item-date\"><span class=\"eventdate\">$eventdate</span></div>";
+  		}
+  		//Display summary text IF configured, and IF exists
+      if ( $displayParams['summary']==1 AND $event->summary ) {
+        $thehtml .= "<div class=\"civieventlist-item-summary\"><span class=\"eventsummary\">{$event->summary}</span></div>";
+  		}
+  		$thehtml .= '</li>';
+  		echo $thehtml;
+    }
+  }
+  
+  echo '</ul>';
+} else {
+  if ($params->get('noeventtext','')) {
+    echo '<div class="civieventlist-no-events">'.htmlspecialchars($params->get('noeventtext','')).'</div>';
+  }
+}


### PR DESCRIPTION
Added parameter "includecss" to use supplied style sheet
Added parameter "noeventtext" to display if no events are found
Style sheet inclusion is now conditional, and properly injects it into
the <head> element.
Added detection for number of events to render.
Removed <br /> formatting.
Added CSS classes to <li>, <a>, and new <div> containers for more
flexible formatting.
