### PR TITLE
Add module class suffix

### DIFF
--- a/mod_civievent.xml
+++ b/mod_civievent.xml
@@ -120,6 +120,12 @@
         <field name="itemid" type="menuitem" state="1" label="Menu Item" description="Select which existing menu item the search result links should be assigned to." />
 
       </fieldset>
+      <fieldset name="advanced">
+        <field name="moduleclass_sfx" type="textarea" rows="3"
+               label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
+               description="COM_MODULES_FIELD_MODULECLASS_SFX_DESC" />
+      </fieldset>
+
     </fields>
   </config>
 </extension>


### PR DESCRIPTION
This patch adds support for the "module class suffix" like Custom HTML modules have.
